### PR TITLE
Add GNOME Screenshot to the Linux instructions

### DIFF
--- a/public/linux.html
+++ b/public/linux.html
@@ -243,26 +243,38 @@
           </div>
           <div class="step-half step-diagram"></div>
         </section>
-        <section class="step" id="alternative-tools">
+      </article>
+      <article id="alternative-tools">
+        <section class="intro">
+          <h1 class="intro-title">Alternative Screenshot Tools</h1>
+          <p>
+            You may be in a situation where you don't have
+            <kbd>Print Screen</kbd>, or your graphical interface doesn't have a
+            built-in screenshot function. In that case, there are screenshot
+            utilities you can install, with the easiest being
+            <a href="https://gitlab.gnome.org/GNOME/gnome-screenshot"
+              >GNOME Screenshot</a
+            >.
+          </p>
+        </section>
+        <section class="step" id="alternative-tools-1">
           <div class="step-half step-text">
-            <h2 class="step-title">Alternative Screenshot Tools</h2>
-            <p>
-              You may be in a situation where you don't have
-              <kbd>Print Screen</kbd>, or your graphical interface doesn't have
-              a built-in screenshot function. In that case, there are screenshot
-              utilities you can install, with the easiest being
-              <a href="https://gitlab.gnome.org/GNOME/gnome-screenshot"
-                >GNOME Screenshot</a
-              >.
-            </p>
             <h2 class="step-title">1</h2>
             <p>Open GNOME Screenshot.</p>
+          </div>
+        </section>
+        <section class="step" id="alternative-tools-1">
+          <div class="step-half step-text">
             <h2 class="step-title">2</h2>
             <p>
               Select "Screen" to take a screenshot of all connected displays,
               "Window" to select a window to screenshot, and "Selection" to draw
               a region.
             </p>
+          </div>
+        </section>
+        <section class="step" id="alternative-tools-1">
+          <div class="step-half step-text">
             <h2 class="step-title">3</h2>
             <p>
               GNOME Screenshot will either save to <code>~/Pictures</code> or

--- a/public/linux.html
+++ b/public/linux.html
@@ -243,6 +243,33 @@
           </div>
           <div class="step-half step-diagram"></div>
         </section>
+        <section class="step" id="alternative-tools">
+          <div class="step-half step-text">
+            <h2 class="step-title">Alternative Screenshot Tools</h2>
+            <p>
+              You may be in a situation where you don't have
+              <kbd>Print Screen</kbd>, or your graphical interface doesn't have
+              a built-in screenshot function. In that case, there are screenshot
+              utilities you can install, with the easiest being
+              <a href="https://gitlab.gnome.org/GNOME/gnome-screenshot"
+                >GNOME Screenshot</a
+              >.
+            </p>
+            <h2 class="step-title">1</h2>
+            <p>Open GNOME Screenshot.</p>
+            <h2 class="step-title">2</h2>
+            <p>
+              Select "Screen" to take a screenshot of all connected displays,
+              "Window" to select a window to screenshot, and "Selection" to draw
+              a region.
+            </p>
+            <h2 class="step-title">3</h2>
+            <p>
+              GNOME Screenshot will either save to <code>~/Pictures</code> or
+              open a dialog window, depending on your desktop environment.
+            </p>
+          </div>
+        </section>
       </article>
     </main>
     <footer>

--- a/public/script.js
+++ b/public/script.js
@@ -9,10 +9,10 @@
 if ("serviceWorker" in navigator) {
   navigator.serviceWorker
     .register("/sw.js")
-    .then(function() {
+    .then(function () {
       console.log("SW registration success");
     })
-    .catch(function(err) {
+    .catch(function (err) {
       console.error("SW registration failed");
       console.error(err);
     });

--- a/public/sw.js
+++ b/public/sw.js
@@ -6,20 +6,22 @@
 // Often the same people come back to the site, and since they get the cached version it may
 // be some time before they get actual current content.
 
-self.addEventListener('install', () => {
+self.addEventListener("install", () => {
   self.skipWaiting();
 });
 
-self.addEventListener('activate', () => {
+self.addEventListener("activate", () => {
   // Optional: Get a list of all the current open windows/tabs under
   // our service worker's control, and force them to reload.
   // This can "unbreak" any open windows/tabs as soon as the new
   // service worker activates, rather than users having to manually reload.
-  self.clients.matchAll({
-    type: 'window'
-  }).then(windowClients => {
-    windowClients.forEach((windowClient) => {
-      windowClient.navigate(windowClient.url);
+  self.clients
+    .matchAll({
+      type: "window",
+    })
+    .then((windowClients) => {
+      windowClients.forEach((windowClient) => {
+        windowClient.navigate(windowClient.url);
+      });
     });
-  });
 });

--- a/public/windows.html
+++ b/public/windows.html
@@ -34,7 +34,7 @@
     <script
       async
       defer
-      data-do-not-track='true'
+      data-do-not-track="true"
       data-website-id="6ad9bbee-67d0-4792-996c-3e15ab0e9742"
       src="https://analytics.sthom.kiwi/umami.js"
     ></script>
@@ -319,8 +319,8 @@
                 class="svg-fill"
               >
                 %USERPROFILE%\Pictures\Screenshots
-              </text> -->
-            </svg>
+              </text>
+            </svg> -->
           </div>
         </section>
       </article>


### PR DESCRIPTION
This change adds instructions for GNOME Screenshot, for users who may be on a WM/DE without a built-in screenshot function. Closes #16.

Also moved a misplaced comment ending in `windows.html`.