### PR TITLE
Add extra sections describing how to get screenshots off Switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A few points to consider as you make changes:
 A big thank you to the following people for their contributions to this project:
 
 - [@ExperiBass](https://github.com/ExperiBass): Adding instructions for GNOME screenshot to the Linux page
+- [@dgw](https://github.com/dgw): Adding instructions for transferring screenshots off of Switch
 
 ### Things to work on
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": " ",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prettier": "prettier --write \"{public,src}/**/*.{js,html,css,json,svg}\""
+    "prettier": "prettier --write \"public/**/*.{js,html,css,json,svg}\""
   },
   "author": "Stuart Thomson",
   "license": "MIT",

--- a/public/playstation.html
+++ b/public/playstation.html
@@ -331,7 +331,7 @@
           <div class="step-half step-text">
             <h2 class="step-title">3</h2>
             <p>
-              You screenshot can be found in the <em>Capture Gallery</em> app.
+              Your screenshot can be found in the <em>Capture Gallery</em> app.
             </p>
           </div>
           <div class="step-half step-diagram">

--- a/public/switch.html
+++ b/public/switch.html
@@ -230,7 +230,7 @@
             <p>
               For further details, see
               <a
-                href="https://en-americas-support.nintendo.com/app/answers/detail/a_id/53664/~/how-to-transfer-screenshots-and-video-captures-to-a-computer-via-a-usb-cable"
+                href="https://en-americas-support.nintendo.com/app/answers/detail/a_id/53664/"
                 >Nintendo's documentation</a
               >. It is also possible to transfer screenshots by using a microSD
               memory card.
@@ -269,7 +269,7 @@
               Once the device connects, your Switch will send the selected
               screenshot(s) to it. For more information, see
               <a
-                href="https://en-americas-support.nintendo.com/app/answers/detail/a_id/53138/~/how-to-transfer-screenshots-and-video-captures-to-a-smart-device-wirelessly"
+                href="https://en-americas-support.nintendo.com/app/answers/detail/a_id/53138/"
                 >Nintendo's instructions</a
               >.
             </p>

--- a/public/switch.html
+++ b/public/switch.html
@@ -209,11 +209,31 @@
           <div class="step-half step-text">
             <h2 class="step-title">Extra: USB</h2>
             <p>
-              You can transfer your screenshots to a computer by following
+              You can transfer your Switch screenshots to a computer via a USB
+              cable:
+            </p>
+            <ol>
+              <li>
+                From the Switch's home menu, select <strong>Settings</strong>,
+                <strong>Data Management</strong>,
+                <strong>Manage Screenshots &amp; Videos</strong>
+              </li>
+              <li>
+                Select <strong>Copy to a Computer via USB Connection</strong>
+              </li>
+              <li>
+                Connect your Switch <em>directly</em> to a computer (not via a
+                dock)
+              </li>
+              <li>Choose which screenshots to transfer</li>
+            </ol>
+            <p>
+              For further details, see
               <a
                 href="https://en-americas-support.nintendo.com/app/answers/detail/a_id/53664/~/how-to-transfer-screenshots-and-video-captures-to-a-computer-via-a-usb-cable"
                 >Nintendo's documentation</a
-              >.
+              >. It is also possible to transfer screenshots by using a microSD
+              memory card.
             </p>
           </div>
           <div class="step-half step-diagram">
@@ -230,7 +250,24 @@
             <h2 class="step-title">Extra: Smart Device</h2>
             <p>
               You can transfer your screenshots to a smart device (phone,
-              tablet) by following
+              tablet) wirelessly:
+            </p>
+            <ol>
+              <li>Select a screenshot from the <strong>Album</strong></li>
+              <li>
+                Choose <strong>Sharing and Editing</strong>, then
+                <strong>Send to Smartphone</strong><br />
+                You can transfer <strong>Only This One</strong> or select more
+                to <strong>Send a Batch</strong>
+              </li>
+              <li>
+                The Switch will display a QR code for you to scan using the
+                camera on your other device.
+              </li>
+            </ol>
+            <p>
+              Once the device connects, your Switch will send the selected
+              screenshot(s) to it. For more information, see
               <a
                 href="https://en-americas-support.nintendo.com/app/answers/detail/a_id/53138/~/how-to-transfer-screenshots-and-video-captures-to-a-smart-device-wirelessly"
                 >Nintendo's instructions</a

--- a/public/switch.html
+++ b/public/switch.html
@@ -225,6 +225,19 @@
             </svg>
           </div>
         </section>
+        <section class="step" id="full-extra-smart-device">
+          <div class="step-half step-text">
+            <h2 class="step-title">Extra: Smart Device</h2>
+            <p>
+              You can transfer your screenshots to a smart device (phone,
+              tablet) by following
+              <a
+                href="https://en-americas-support.nintendo.com/app/answers/detail/a_id/53138/~/how-to-transfer-screenshots-and-video-captures-to-a-smart-device-wirelessly"
+                >Nintendo's instructions</a
+              >.
+            </p>
+          </div>
+        </section>
       </article>
     </main>
     <footer>

--- a/public/switch.html
+++ b/public/switch.html
@@ -205,6 +205,26 @@
             </svg>
           </div>
         </section>
+        <section class="step" id="full-extra-USB">
+          <div class="step-half step-text">
+            <h2 class="step-title">Extra: USB</h2>
+            <p>
+              You can transfer your screenshots to a computer by following
+              <a
+                href="https://en-americas-support.nintendo.com/app/answers/detail/a_id/53664/~/how-to-transfer-screenshots-and-video-captures-to-a-computer-via-a-usb-cable"
+                >Nintendo's documentation</a
+              >.
+            </p>
+          </div>
+          <div class="step-half step-diagram">
+            <svg viewBox="0 0 475.2 228.1">
+              <path
+                class="svg-fill"
+                d="M356 114.1l-26.3-15.2v10.8H195.3L221.4 82c2.2-1.8 5.1-3 8.1-3.1h22c1.8 5.1 6.6 8.8 12.4 8.8 7.3 0 13.2-5.9 13.2-13.2 0-7.3-5.9-13.2-13.2-13.2-5.7 0-10.6 3.7-12.4 8.8h-21.7c-5.9 0-12.1 3.2-16 7 .1-.1.2-.2 0 0-.1.1-27.8 29.3-27.8 29.3-2.2 1.8-5.1 3-8.1 3.1h-15.2c-2-10-10.9-17.6-21.5-17.6-12.1 0-22 9.8-22 22 0 12.1 9.8 22 22 22 10.6 0 19.5-7.6 21.5-17.6h48c3 .1 5.9 1.3 8.1 3.1 0 0 27.7 29.2 27.8 29.3.2.2.1.1 0 0 3.9 3.8 10.1 7 16 7h20.9v8.8H310v-26.3h-26.3v8.8h-21.2c-3-.1-5.9-1.3-8.1-3.1l-26.2-27.7h101.6v10.9l26.2-15z"
+              />
+            </svg>
+          </div>
+        </section>
       </article>
     </main>
     <footer>


### PR DESCRIPTION
I dropped a link to the Switch page in a reddit thread, and the person I replied to pointed out that it didn't say anything about how to get the screenshots _off_ of the Switch and onto another device that could be used to post them somewhere asking for help. Thought I might as well roll up my sleeves and try to improve the page myself.

While I don't own a Switch, Nintendo's help pages provided a good reference for throwing together basic instructions supplemented by links directly to those help documents.

Before pushing, I ran `npm run prettier` but only committed the changes it made to my own patch. (The changes `prettier` made to some of the SVG files in `src/` were actually rather ugly, too.)