### PR TITLE
POC: Add info about screenshot app on MacOS (without graphics)

### DIFF
--- a/public/mac.html
+++ b/public/mac.html
@@ -303,6 +303,40 @@
           </div>
         </section>
       </article>
+      <article>
+        <section class="intro">
+          <h1 class="intro-title">Using screenshot app</h1>
+          <p>
+            MacOS has also build-in screenshot app, that let's you select a part
+            of a screen, a particular window, or even create a screen record
+          </p>
+        </section>
+        <section class="step">
+          <div class="step-half step-text">
+            <h2 class="step-title">1</h2>
+            <p>
+              Press the <kbd>Command</kbd> + <kbd>Space</kbd> to open Spotlight
+            </p>
+          </div>
+        </section>
+        <section class="step">
+          <div class="step-half step-text">
+            <h2 class="step-title">2</h2>
+            <p>Type in "Screenshot" and open the "Screenshot" app</p>
+          </div>
+        </section>
+        <section class="step">
+          <div class="step-half step-text">
+            <h2 class="step-title">3</h2>
+            <p>
+              From the menu-bar select the mode (full-screen, window or partial)
+              and click capture to take a screenshot. From that bar you can also
+              set, if you want your screenshot to be saved or to be copied to
+              the clipboard
+            </p>
+          </div>
+        </section>
+      </article>
     </main>
     <footer>
       <p>

--- a/public/script.js
+++ b/public/script.js
@@ -38,7 +38,7 @@ function userAgentDetectDevice() {
     return "windows";
   }
   if (navigator.userAgent.indexOf("Macintosh") !== -1) {
-    return 'mac';
+    return "mac";
   }
   if (navigator.userAgent.indexOf("Linux") !== -1) {
     return "linux";
@@ -102,7 +102,7 @@ if (document.getElementById("detectDeviceMessage")) {
     detectDeviceMessage.appendChild(document.createTextNode("You are using "));
 
     const deviceLink = document.createElement("a");
-    deviceLink.classList.add('keep-underline')
+    deviceLink.classList.add("keep-underline");
     deviceLink.href = "/" + device;
     deviceLink.textContent = DEVICE_STRINGS[device];
     detectDeviceMessage.appendChild(deviceLink);


### PR DESCRIPTION
The current MacOS instruction is missing the easiest way (in my opinion), that uses Spotlight to opend a screenshot app, that gives a lot of options without a hustle to remember a really weird keyboard combo.

Here's a suggestion to add that to the current insturction. In this PR the diagrams are missing, but I'll leave adding them for somebody with the Illustrator